### PR TITLE
make it #[no_std] compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,17 @@ repository = "https://github.com/argumentcomputer/neptune"
 rust-version = "1.71.0"
 
 [dependencies]
-bellpepper = { workspace = true }
-bellpepper-core = { workspace = true }
+bellpepper = { workspace = true, optional = true }
+bellpepper-core = { workspace = true, optional = true }
 blake2s_simd = { workspace = true }
 blstrs = { workspace = true, optional = true }
-byteorder = { workspace = true }
 ec-gpu = { workspace = true, optional = true }
 ec-gpu-gen = { workspace = true, optional = true }
-ff ={ workspace = true }
+libm = { workspace = true }
+ff = { workspace = true }
 generic-array = { workspace = true }
 pasta_curves = { workspace = true, features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 trait-set = "0.3.0"
 abomonation = { version = "0.7.3", optional = true }
 abomonation_derive = { version = "0.1.0", package = "abomonation_derive_ng", optional = true }
@@ -57,7 +57,7 @@ incremental = false
 codegen-units = 1
 
 [features]
-default = ["bls", "pasta"]
+default = ["std", "bls", "pasta"]
 cuda = ["ec-gpu-gen/cuda", "ec-gpu"]
 opencl = ["ec-gpu-gen/opencl", "ec-gpu"]
 # The supported arities for Poseidon running on the GPU are specified at compile-time.
@@ -74,6 +74,7 @@ strengthened = []
 bls = ["blstrs/gpu"]
 pasta = ["pasta_curves/gpu"]
 portable = ["blstrs/portable"]
+std = ["dep:serde", "dep:bellpepper", "dep:bellpepper-core"]
 # Unsafe Abomonation-based serialization
 abomonation = ["dep:abomonation", "dep:abomonation_derive"]
 
@@ -90,6 +91,7 @@ bellpepper = { version = "0.4.0", default-features = false }
 blake2s_simd = "1.0.1"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"
+libm = "0.2.8"
 generic-array = "1.0"
 pasta_curves = { version = "0.5" }
 ec-gpu = { version = "0.2.0" }

--- a/src/column_tree_builder.rs
+++ b/src/column_tree_builder.rs
@@ -49,7 +49,7 @@ where
         let end = start + column_count;
 
         if end > self.leaf_count {
-            return Err(Error::Other("too many columns".to_string()));
+            return Err(Error::Other("too many columns"));
         }
 
         match self.column_batcher {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
-use std::{error, fmt};
+use core::fmt;
+
 
 #[derive(Debug, Clone)]
 #[cfg(any(feature = "cuda", feature = "opencl"))]
@@ -47,10 +48,11 @@ pub enum Error {
     FullBuffer,
     /// Attempt to reference an index element that is out of bounds
     IndexOutOfBounds,
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     GpuError(String),
     #[cfg(any(feature = "cuda", feature = "opencl"))]
     ClError(ClError),
-    Other(String),
+    Other(&'static str),
 }
 
 #[cfg(any(feature = "cuda", feature = "opencl"))]
@@ -67,9 +69,10 @@ impl From<ec_gpu_gen::EcError> for Error {
     }
 }
 
-impl error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
-impl fmt::Display for Error {
+impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Error::FullBuffer => write!(
@@ -77,6 +80,7 @@ impl fmt::Display for Error {
                 "The size of the buffer cannot be greater than the hash arity."
             ),
             Error::IndexOutOfBounds => write!(f, "The referenced index is outs of bounds."),
+            #[cfg(any(feature = "cuda", feature = "opencl"))]
             Error::GpuError(s) => write!(f, "GPU Error: {s}"),
             #[cfg(any(feature = "cuda", feature = "opencl"))]
             Error::ClError(e) => write!(f, "OpenCL Error: {e}"),

--- a/src/hash_type.rs
+++ b/src/hash_type.rs
@@ -16,11 +16,13 @@ use abomonation::Abomonation;
 #[cfg(feature = "abomonation")]
 use abomonation_derive::Abomonation;
 use ff::PrimeField;
+#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(bound(serialize = "F: Serialize", deserialize = "F: Deserialize<'de>")))]
 #[cfg_attr(feature = "abomonation", derive(Abomonation))]
-#[serde(bound(serialize = "F: Serialize", deserialize = "F: Deserialize<'de>"))]
 #[cfg_attr(feature = "abomonation", abomonation_omit_bounds)]
 pub enum HashType<F: PrimeField, A: Arity<F>> {
     MerkleTree,
@@ -73,7 +75,8 @@ impl<F: PrimeField, A: Arity<F>> HashType<F, A> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "abomonation", derive(Abomonation))]
 #[cfg_attr(feature = "abomonation", abomonation_omit_bounds)]
 pub enum CType<F: PrimeField, A: Arity<F>> {
@@ -82,7 +85,7 @@ pub enum CType<F: PrimeField, A: Arity<F>> {
     // This is a bit of a hack, but since `serde(skip)` tags the last variant arm,
     // the generated code ends up being correct. But, in the future, do not
     // carelessly add new variants to this enum.
-    #[serde(skip)]
+    #[cfg_attr(feature = "std", serde(skip))]
     #[cfg_attr(feature = "abomonation", abomonation_skip)]
     _Phantom((F, A)),
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::ptr_arg)]
 
 use ff::PrimeField;
+use crate::Vec;
 
 /// Matrix functions here are, at least for now, quick and dirty — intended only to support precomputation of poseidon optimization.
 
@@ -116,7 +117,7 @@ pub(crate) fn left_apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F>
         "Matrix can only be applied to vector of same size."
     );
 
-    let mut result = vec![F::ZERO; v.len()];
+    let mut result = alloc::vec![F::ZERO; v.len()];
 
     for (result, row) in result.iter_mut().zip(m.iter()) {
         for (mat_val, vec_val) in row.iter().zip(v) {
@@ -137,7 +138,7 @@ pub(crate) fn apply_matrix<F: PrimeField>(m: &Matrix<F>, v: &[F]) -> Vec<F> {
         "Matrix can only be applied to vector of same size."
     );
 
-    let mut result = vec![F::ZERO; v.len()];
+    let mut result = alloc::vec![F::ZERO; v.len()];
     for (j, val) in result.iter_mut().enumerate() {
         for (i, row) in m.iter().enumerate() {
             let mut tmp = row[j];
@@ -165,7 +166,7 @@ pub(crate) fn transpose<F: PrimeField>(matrix: &Matrix<F>) -> Matrix<F> {
 
 #[allow(clippy::needless_range_loop)]
 pub(crate) fn make_identity<F: PrimeField>(size: usize) -> Matrix<F> {
-    let mut result = vec![vec![F::ZERO; size]; size];
+    let mut result = alloc::vec![alloc::vec![F::ZERO; size]; size];
     for i in 0..size {
         result[i][i] = F::ONE;
     }

--- a/src/mds.rs
+++ b/src/mds.rs
@@ -6,6 +6,7 @@ use abomonation::Abomonation;
 #[cfg(feature = "abomonation")]
 use abomonation_derive::Abomonation;
 use ff::PrimeField;
+#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
 use crate::matrix;
@@ -13,8 +14,10 @@ use crate::matrix::{
     apply_matrix, invert, is_identity, is_invertible, is_square, left_apply_matrix, mat_mul, minor,
     transpose, Matrix,
 };
+use crate::Vec;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "abomonation", derive(Abomonation))]
 #[cfg_attr(feature = "abomonation", abomonation_bounds(where F::Repr: Abomonation))]
 pub struct MdsMatrices<F: PrimeField> {
@@ -58,7 +61,8 @@ pub(crate) fn derive_mds_matrices<F: PrimeField>(m: Matrix<F>) -> MdsMatrices<F>
 /// This means its first row and column are each dense, and the interior matrix
 /// (minor to the element in both the row and column) is the identity.
 /// We will pluralize this compact structure `sparse_matrixes` to distinguish from `sparse_matrices` from which they are created.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "abomonation", derive(Abomonation))]
 #[cfg_attr(feature = "abomonation", abomonation_bounds(where F::Repr: Abomonation))]
 pub struct SparseMatrix<F: PrimeField> {
@@ -174,12 +178,12 @@ fn make_prime<F: PrimeField>(m: &Matrix<F>) -> Matrix<F> {
         .enumerate()
         .map(|(i, row)| match i {
             0 => {
-                let mut new_row = vec![F::ZERO; row.len()];
+                let mut new_row = alloc::vec![F::ZERO; row.len()];
                 new_row[0] = F::ONE;
                 new_row
             }
             _ => {
-                let mut new_row = vec![F::ZERO; row.len()];
+                let mut new_row = alloc::vec![F::ZERO; row.len()];
                 new_row[1..].copy_from_slice(&row[1..]);
                 new_row
             }
@@ -201,7 +205,7 @@ fn make_double_prime<F: PrimeField>(m: &Matrix<F>, m_hat_inv: &Matrix<F>) -> Mat
                 new_row
             }
             _ => {
-                let mut new_row = vec![F::ZERO; row.len()];
+                let mut new_row = alloc::vec![F::ZERO; row.len()];
                 new_row[0] = w_hat[i - 1];
                 new_row[i] = F::ONE;
                 new_row

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -14,10 +14,12 @@ use abomonation::Abomonation;
 use abomonation_derive::Abomonation;
 use ff::PrimeField;
 use generic_array::{sequence::GenericSequence, typenum, ArrayLength, GenericArray};
+#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 use typenum::marker_traits::Unsigned;
 use typenum::*;
+use crate::Vec;
 
 /// Available arities for the Poseidon hasher.
 pub trait Arity<T>: ArrayLength {
@@ -868,12 +870,12 @@ where
             }
         }
 
-        let _ = std::mem::replace(&mut self.elements, result);
+        let _ = core::mem::replace(&mut self.elements, result);
     }
 
     pub(crate) fn product_mds_with_matrix_left(&mut self, matrix: &Matrix<F>) {
         let result = left_apply_matrix(matrix, &self.elements);
-        let _ = std::mem::replace(
+        let _ = core::mem::replace(
             &mut self.elements,
             GenericArray::<F, A::ConstantsSize>::generate(|i| result[i]),
         );
@@ -900,9 +902,10 @@ where
             val.add_assign(&tmp);
         }
 
-        let _ = std::mem::replace(&mut self.elements, result);
+        let _ = core::mem::replace(&mut self.elements, result);
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn debug(&self, msg: &str) {
         dbg!(msg, &self.constants_offset, &self.elements);
     }

--- a/src/poseidon_alt.rs
+++ b/src/poseidon_alt.rs
@@ -4,6 +4,7 @@
 use crate::poseidon::{Arity, Poseidon};
 use crate::{matrix, quintic_s_box};
 use ff::PrimeField;
+use crate::Vec;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Correct

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -1,6 +1,7 @@
 use crate::matrix::{apply_matrix, left_apply_matrix, vec_add};
 use crate::mds::MdsMatrices;
 use crate::quintic_s_box;
+use crate::Vec;
 use ff::PrimeField;
 
 // - Compress constants by pushing them back through linear layers and through the identity components of partial layers.
@@ -108,7 +109,7 @@ pub(crate) fn compress_round_constants<F: PrimeField>(
         ////////////////////////////////////////////////////////////////////////////////
         // Shared between branches, arbitrary initial state representing the output of a previous round's S-Box layer.
         // X
-        let initial_state = vec![F::ONE; width];
+        let initial_state = alloc::vec![F::ONE; width];
 
         ////////////////////////////////////////////////////////////////////////////////
         // Compute one step with the given (unpreprocessed) constants.

--- a/src/round_constants.rs
+++ b/src/round_constants.rs
@@ -1,4 +1,5 @@
 use ff::PrimeField;
+use crate::Vec;
 
 /// From the paper ():
 /// The round constants are generated using the Grain LFSR [23] in a self-shrinking
@@ -38,7 +39,7 @@ pub(crate) fn generate_constants<F: PrimeField>(
     if n_bytes != 32 {
         unimplemented!("neptune currently supports 32-byte fields exclusively");
     }
-    assert_eq!((f32::from(field_size) / 8.0).ceil() as usize, n_bytes);
+    assert_eq!(field_size.div_ceil(8) as usize, n_bytes);
 
     let num_constants = (r_f + r_p) * t;
     let mut init_sequence: Vec<bool> = Vec::new();

--- a/src/round_numbers.rs
+++ b/src/round_numbers.rs
@@ -37,7 +37,7 @@ pub(crate) fn round_numbers_strengthened(arity: usize) -> (usize, usize) {
     let (full_round, partial_rounds) = round_numbers_base(arity);
 
     // Increase by 25%, rounding up.
-    let strengthened_partial_rounds = f64::ceil(partial_rounds as f64 * 1.25) as usize;
+    let strengthened_partial_rounds = libm::ceil(partial_rounds as f64 * 1.25) as usize;
 
     (full_round, strengthened_partial_rounds)
 }
@@ -55,7 +55,7 @@ pub(crate) fn calc_round_numbers(t: usize, security_margin: bool) -> (usize, usi
             if round_numbers_are_secure(t, rf_test, rp_test) {
                 if security_margin {
                     rf_test += 2;
-                    rp_test = (1.075 * rp_test as f32).ceil() as usize;
+                    rp_test = libm::ceilf(1.075 * rp_test as f32) as usize;
                 }
                 let n_sboxes = n_sboxes(t, rf_test, rp_test);
                 if n_sboxes < n_sboxes_min || (n_sboxes == n_sboxes_min && rf_test < rf) {
@@ -79,12 +79,12 @@ fn round_numbers_are_secure(t: usize, rf: usize, rp: usize) -> bool {
     } else {
         10.0
     };
-    let rf_interp = 0.43 * m + t.log2() - rp;
+    let rf_interp = 0.43 * m + libm::log2f(t) - rp;
     let rf_grob_1 = 0.21 * n - rp;
     let rf_grob_2 = (0.14 * n - 1.0 - rp) / (t - 1.0);
     let rf_max = [rf_stat, rf_interp, rf_grob_1, rf_grob_2]
         .iter()
-        .map(|rf| rf.ceil() as usize)
+        .map(|rf| libm::ceilf(*rf) as usize)
         .max()
         .unwrap();
     rf >= rf_max

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -41,7 +41,7 @@ where
         let end = start + batch_leaf_count;
 
         if end > self.leaf_count {
-            return Err(Error::Other("too many leaves".to_string()));
+            return Err(Error::Other("too many leaves"));
         }
 
         self.data[start..end].copy_from_slice(leaves);


### PR DESCRIPTION
This PR makes it `#[no_std]` compatible. 
It was tested in a substrate pallet extrinsic and called in `polkadot.js.org` explorer:

```rust
        pub fn test_neptune(origin: OriginFor<T>) -> DispatchResult {
            let _caller = ensure_signed(origin)?;

            let constants: PoseidonConstants<Fr, U8> = PoseidonConstants::new();
            let mut preimage = [Fr::ZERO; 8];
            preimage[0] = <Fr as Field>::ONE;

            let mut h = Poseidon::<Fr, U8>::new_with_preimage(&preimage, &constants);
            let _aa = h.hash();

            Ok(())
        }
```


